### PR TITLE
using the original backbone loadUrl instead of duplicating its content

### DIFF
--- a/backbone.analytics.js
+++ b/backbone.analytics.js
@@ -1,18 +1,12 @@
 (function() {
-  var _loadUrl = Backbone.History.prototype.loadUrl;
-
+  var loadUrl = Backbone.History.prototype.loadUrl;
+  
   Backbone.History.prototype.loadUrl = function(fragmentOverride) {
-    var fragment = this.fragment = this.getFragment(fragmentOverride);
-      var matched = _.any(this.handlers, function(handler) {
-        if (handler.route.test(fragment)) {
-          handler.callback(fragment);
-          return true;
-        }
-      });
-
-    if (!/^\//.test(fragment)) fragment = '/' + fragment;
-    if (window._gaq !== undefined) window._gaq.push(['_trackPageview', fragment]);
-
+    var matched = loadUrl.apply(this, arguments),
+        gaFragment = this.fragment;
+    if (!/^\//.test(gaFragment)) gaFragment = '/' + gaFragment;
+    if(window._gaq !== undefined) window._gaq.push(['_trackPageview', gaFragment]);
+    
     return matched;
   };
 


### PR DESCRIPTION
- used the original loadUrl instead of duplicating its content
- fixed the fragment to send to ga, without altering the History fragment property
