### PR TITLE
Direct lookup for window.ga

### DIFF
--- a/backbone.analytics.js
+++ b/backbone.analytics.js
@@ -13,9 +13,11 @@
     var matched = loadUrl.apply(this, arguments),
         gaFragment = this.fragment;
     if (!/^\//.test(gaFragment)) gaFragment = '/' + gaFragment;
+    // legacy version
     if(typeof window._gaq !== "undefined") window._gaq.push(['_trackPageview', gaFragment]);
-    if(typeof window['GoogleAnalyticsObject'] !== "undefined"){
-      var ga = window['GoogleAnalyticsObject'];
+    // Analytics.js
+    var ga = window['GoogleAnalyticsObject'] || window.ga;
+    if(typeof ga !== "undefined"){
       ga('send', 'pageview', gaFragment);
     }
     return matched;


### PR DESCRIPTION
I had an issue when loading Analytics.js with Require.js because the `GoogleAnalyticsObject` is defined in the sample embed code. 

This commit fallbacks to the actual `window.ga` object if `GoogleAnalyticsObject` is not defined.
