### PR TITLE
Fixed JSHint errors + fixed global analytics variable issue

### DIFF
--- a/backbone.analytics.js
+++ b/backbone.analytics.js
@@ -29,7 +29,13 @@
     }
 
     // Analytics.js
-    var ga = window.GoogleAnalyticsObject || window.ga;
+    var ga;
+    if (window.GoogleAnalyticsObject && window.GoogleAnalyticsObject !== 'ga') {
+      ga = window.GoogleAnalyticsObject;
+    } else {
+      ga = window.ga;
+    }
+
     if (typeof ga !== 'undefined') {
       ga('send', 'pageview', gaFragment);
     }


### PR DESCRIPTION
This pull request contains two commits which address the following:

1.) Fixed JSHint errors.

2.) Fixed an issue where window.GoogleAnalyticsObject could be set to the string 'ga'. I'm not sure if others ran into this issue, but I noticed it in an app using require.js.

All tests appear to be passing and I've tried to stay close to the current coding style.

Thanks
