### PR TITLE
Don't track a pageview for the original route when the router is not started silently.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ A drop-in plugin that integrates Google's `trackEvent` directly into Backbone's 
 
 Add the [asynchronous Google Analytics code](http://code.google.com/apis/analytics/docs/tracking/asyncTracking.html) to your site.
 
-If you run `Backbone.history.start()` with the `silent: false` option (it's the default) then you may want to remove the following line from your tracking snippet to prevent Google from possibly double counting the initial page load.
-`_gaq.push(['_trackPageview']);`
-
 Add these dependencies to your site's `<head>`, **in order**:
 
 ```

--- a/backbone.analytics.js
+++ b/backbone.analytics.js
@@ -19,6 +19,11 @@
     var matched = loadUrl.apply(this, arguments),
         gaFragment = this.fragment;
 
+    if (!this.options.silent) {
+      this.options.silent = true;
+      return matched;
+    }
+    
     if (!/^\//.test(gaFragment)) {
       gaFragment = '/' + gaFragment;
     }


### PR DESCRIPTION
This way, manually removing `_gaq.push(['_trackPageview']);` or `ga('send', 'pageview');` is no longer necessary.
